### PR TITLE
Bring test runner to interface version 3

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -238,7 +238,7 @@ tool_versions() {
                 elif command -v uname >/dev/null; then
                     uname -sro
                 else
-                    echo "doesn't look like linux..."
+                    echo "Doesn't look like Linux..."
                 fi
             )" \
         '$ARGS.named'

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -14,8 +14,8 @@
 # then parses that TAP file to produce the JSON file.
 
 # the version of the test-runner interface:
-# https://github.com/exercism/docs/blob/50bcff91e8871f08b9a69b76ccbd45e5a90493dd/building/tooling/test-runners/interface.md
-INTERFACE_VERSION=2
+# https://exercism.org/docs/building/tooling/test-runners/interface
+INTERFACE_VERSION=3
 
 main() {
     echo "Running exercise tests for AWK"
@@ -35,6 +35,7 @@ main() {
     local json_result_file="$output_dir/results.json"
 
     local -A test_bodies    # populated in get_test_bodies
+    local -A task_ids       # populated in get_test_bodies
 
     run_tests "$slug" "$solution_dir" "$output_file"
     build_report "$output_file" "$json_result_file"
@@ -75,10 +76,11 @@ run_tests() {
 
 get_test_bodies() {
     local test_file=$1
-    local name line indent
+    local name line indent task_id
     local state="out"
     local body=()
     test_bodies=()
+    task_ids=()
 
     local start_test_re='^@test ['\''"](.+)['\''"] \{[[:blank:]]*$'
     local end_test_re='^\}[[:blank:]]*$'
@@ -90,11 +92,15 @@ get_test_bodies() {
                     name=${BASH_REMATCH[1]}
                     body=()
                     state="in"
+                    unset task_id
                 fi
                 ;;
             in)
                 if [[ $line =~ $end_test_re ]]; then
                     test_bodies["$name"]=$(printf '%s\n' "${body[@]}")
+                    if [[ -v task_id ]]; then
+                        task_ids["$name"]=$task_id
+                    fi
                     state="out"
                 elif [[ $line == *BATS_RUN_SKIPPED*skip* ]]; then
                     # skip the skips
@@ -102,6 +108,8 @@ get_test_bodies() {
                 elif ((${#body[@]} == 0)) && [[ $line == *([[:blank:]]) ]]; then
                     # ignore blank lines at the top of the test body
                     continue
+                elif [[ $line =~ "## task "([0-9]+) ]]; then
+                    task_id=${BASH_REMATCH[1]}
                 else
                     # We want to unindent the body: find the indentation of the first line.
                     ((${#body[@]} == 0)) && indent=${line%%[^[:blank:]]*}
@@ -223,27 +231,44 @@ tool_versions() {
     jq  --null-input \
         --arg gawk "$(gawk --version | head -1)" \
         --arg bats "$(bats --version)" \
-        --arg OS "$(. /etc/lsb-release; echo "$DISTRIB_DESCRIPTION")" \
+        --arg OS "$(
+                # probably don't need this complexity, but ...
+                if [[ -f /etc/lsb-release ]]; then
+                    . /etc/lsb-release; echo "$DISTRIB_DESCRIPTION"
+                elif command -v uname >/dev/null; then
+                    uname -sro
+                else
+                    echo "doesn't look like linux..."
+                fi
+            )" \
         '$ARGS.named'
 }
 
 print_failed_test() {
     # Print result of failed test as JSON.
-    jq  --null-input \
-        --arg name "$1" \
-        --arg message "$2" \
-        --arg code "$3" \
-        --arg status "fail" \
-        '{name: $name, status: $status, test_code: $code, message: $message}'
+    local args=(
+        --arg name "$1"
+        --arg status "fail"
+        --arg test_code "$3"
+        --arg message "$2"
+    )
+    if [[ "${task_ids["$1"]}" ]]; then
+        args+=( --arg task_id "${task_ids["$1"]}" )
+    fi
+    jq --null-input "${args[@]}" '$ARGS.named'
 }
 
 print_passed_test() {
     # Print result of passed test as JSON.
-    jq  --null-input \
-        --arg name "$1" \
-        --arg code "$2" \
-        --arg status "pass" \
-        '{name: $name, status: $status, test_code: $code}'
+    local args=(
+        --arg name "$1"
+        --arg status "pass"
+        --arg test_code "$2"
+    )
+    if [[ "${task_ids["$1"]}" ]]; then
+        args+=( --arg task_id "${task_ids["$1"]}" )
+    fi
+    jq --null-input "${args[@]}" '$ARGS.named'
 }
 
 main "$@"

--- a/tests/data/first_fails/expected_results.json
+++ b/tests/data/first_fails/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "test-environment": {
     "bash": "5.0.17(1)-release",

--- a/tests/data/gawk-syntax-error/expected_results.json
+++ b/tests/data/gawk-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "test-environment": {
     "gawk": "GNU Awk 5.1.0, API: 3.0 (GNU MPFR 4.1.0, GNU MP 6.2.1)",

--- a/tests/data/last_fails/expected_results.json
+++ b/tests/data/last_fails/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "tests": [
     {

--- a/tests/data/middle_fails/expected_results.json
+++ b/tests/data/middle_fails/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "tests": [
     {

--- a/tests/data/missing_script/expected_results.json
+++ b/tests/data/missing_script/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "fail",
   "tests": [
     {

--- a/tests/data/one_passing/expected_results.json
+++ b/tests/data/one_passing/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "pass",
   "tests": [
     {

--- a/tests/data/three_passing/expected_results.json
+++ b/tests/data/three_passing/expected_results.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "status": "pass",
   "tests": [
     {

--- a/tests/data/with_tasks/expected_results.json
+++ b/tests/data/with_tasks/expected_results.json
@@ -1,0 +1,24 @@
+{
+  "version": 3,
+  "status": "pass",
+  "tests": [
+    {
+      "name": "say one",
+      "status": "pass",
+      "test_code": "run bash with_tasks.sh one\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"one\" ]",
+      "task_id": "1"
+    },
+    {
+      "name": "say two",
+      "status": "pass",
+      "test_code": "run bash with_tasks.sh two\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"two\" ]",
+      "task_id": "1"
+    },
+    {
+      "name": "say three",
+      "status": "pass",
+      "test_code": "run bash with_tasks.sh three\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"three\" ]",
+      "task_id": "2"
+    }
+  ]
+}

--- a/tests/data/with_tasks/test-with_tasks.bats
+++ b/tests/data/with_tasks/test-with_tasks.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+@test "say one" {
+  ## task 1
+  run bash with_tasks.sh one
+  [ "$status" -eq 0 ]
+  [ "$output" == "one" ]
+}
+
+@test "say two" {
+  ## task 1
+  run bash with_tasks.sh two
+  [ "$status" -eq 0 ]
+  [ "$output" == "two" ]
+}
+
+@test "say three" {
+  ## task 2
+  run bash with_tasks.sh three
+  [ "$status" -eq 0 ]
+  [ "$output" == "three" ]
+}

--- a/tests/data/with_tasks/with_tasks.sh
+++ b/tests/data/with_tasks/with_tasks.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+main() {
+    echo "$1"
+}
+
+main "$@"

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -36,6 +36,15 @@ actual_matches_expected() {
     actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
+@test "with task ids" {
+    TEST="with_tasks"
+    TEST_DIR="$DATA_DIR/$TEST"
+    run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
+
+    [[ "$status" -eq 0 ]]
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
+}
+
 @test "first test fails" {
     TEST="first_fails"
     TEST_DIR="$DATA_DIR/$TEST"


### PR DESCRIPTION
Concept exercises need to link each test to a "task id": This approach scans the body of each test for the magic comment (where N is a whole number)

```sh
## task N
```

See the new file: tests/data/with_tasks/test-with_tasks.bats 

Ref https://exercism.org/docs/building/tooling/test-runners/interface

This should have no effect on the current practice exercises.
