### PR TITLE
 Dockerfile: Add locale support for Unicode (fixes Mazy Mice) & use long options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,17 @@ FROM ubuntu:24.04
 # jq   v1.7.1           https://launchpad.net/ubuntu/noble/+source/jq
 # bats v1.10.0          https://launchpad.net/ubuntu/noble/+source/bats
 
-RUN apt-get update                    && \
-    apt-get install -y gawk jq bats   && \
-    apt-get purge --auto-remove -y    && \
-    apt-get clean                     && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update                                                              && \
+    apt-get install --assume-yes --no-install-recommends gawk jq bats locales   && \
+    sed --in-place '/en_US.UTF-8/s/^# //g' /etc/locale.gen                      && \
+    locale-gen                                                                  && \
+    apt-get purge --auto-remove --assume-yes                                    && \
+    apt-get clean                                                               && \
+    rm --recursive --force /var/lib/apt/lists/*
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -27,10 +27,10 @@ solution_dir=$(realpath "${2%/}")
 output_dir=$(realpath "${3%/}")
 
 # Create the output directory if it doesn't exist
-mkdir -p "${output_dir}"
+mkdir --parents "${output_dir}"
 
 # Build the Docker image
-docker build --rm -t exercism/awk-test-runner .
+docker build --rm --tag exercism/awk-test-runner .
 
 # Run the Docker image using the settings mimicking the production environment
 docker run \


### PR DESCRIPTION
This PR addresses the issue where the `awk-test-runner` Docker image failed to correctly run tests for exercises involving Unicode characters, such as "Mazy Mice" which uses box-drawing symbols. The root cause was the lack of a configured UTF-8 locale in the base image.

This PR also improves the readability of the Dockerfile by using long-form command-line options.

**Changes:**

1.  **Added UTF-8 Locale Support:**
    * Installed the `locales` package via `apt-get install`.
    * Configured and generated the `en_US.UTF-8` locale using `sed` on `/etc/locale.gen` and `locale-gen`.
    * Set the `LANG`, `LANGUAGE`, and `LC_ALL` environment variables to `en_US.UTF-8` to ensure applications within the container correctly handle Unicode.

2.  **Improved Readability:**
    * Replaced short command-line options in the `RUN` command with their long-form equivalents for clarity:
        * `-y` -> `--assume-yes` (for `apt-get install`, `apt-get purge`)
        * `-i` -> `--in-place` (for `sed`)
        * `-r` -> `--recursive` (for `rm`)
        * `-f` -> `--force` (for `rm`)

**Result:**

With these changes, the Docker image now correctly handles Unicode characters, allowing tests for exercises like "Mazy Mice" to pass successfully. The Dockerfile is also slightly more explicit and readable due to the use of long options.

**Testing:**

Confirmed that tests for the "Mazy Mice" exercise pass using the image built from this updated Dockerfile.

**Related Issue:**

Fixes #34 
