### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 # Ubuntu 24.04 'noble numbat' gets us:
 # gawk v5.2.1           https://launchpad.net/ubuntu/noble/+source/gawk

--- a/bin/versions.sh
+++ b/bin/versions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Build the Docker image
+docker build --rm --tag exercism/awk-test-runner .
+
+# Print tool versions inside Docker
+docker run --rm -it --entrypoint /bin/bash exercism/awk-test-runner -c 'for i in awk bats bash jq; do "$i" --version | head -n1; done'


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.